### PR TITLE
ci: make this window bigger due to the way the app works

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ examples/complete/builds
 # using custom git-xargs for commit signing
 git-xargs
 .vscode
+ignore

--- a/renovate.json5
+++ b/renovate.json5
@@ -15,8 +15,8 @@
   // If we don't specify a timezone then Renovate will use UTC
   "timezone": "America/New_York",
   "schedule": [
-    "after 7am and before 8am every weekday",
-    "after 7pm and before 8pm every weekday"
+    "after 7am and before 11am every weekday",
+    "after 7pm and before 11pm every weekday"
   ],
   // This will prevent Renovate from automatically rebasing PRs.
   // Without this, Renovate will rebase PRs whenever it wants to. The 'schedule' param is only for creating PRs. Because we are grouping all changes into one PR without this Renovate will be constantly rebasing that PR which we don't want since every time that happens another set of GHA status checks are kicked off.

--- a/repo_templates/common/repo_files/renovate.json5
+++ b/repo_templates/common/repo_files/renovate.json5
@@ -17,7 +17,7 @@
   "timezone": "America/New_York",
   // fires between 4 am and 5 am EST on mondays
   "schedule": [
-    "after 4am and before 5am on Monday"
+    "after 4am and before 8am on Monday"
   ],
   // This will prevent Renovate from automatically rebasing PRs. Without this, Renovate will rebase PRs whenever it wants to. The 'schedule' param is only for creating PRs. Because we are grouping all changes into one PR without this Renovate will be constantly rebasing that PR which we don't want since every time that happens another set of GHA status checks are kicked off.
   // Using a value of "conflicted" means that Renovate will only rebase PRs if they are in a conflicted state. See https://docs.renovatebot.com/configuration-options/#rebasewhen

--- a/repo_templates/terraform/repo_files/renovate.json5
+++ b/repo_templates/terraform/repo_files/renovate.json5
@@ -17,7 +17,7 @@
   "timezone": "America/New_York",
   // fires between 4 am and 5 am EST on mondays
   "schedule": [
-    "after 4am and before 5am on Monday"
+    "after 4am and before 8am on Monday"
   ],
   // This will prevent Renovate from automatically rebasing PRs. Without this, Renovate will rebase PRs whenever it wants to. The 'schedule' param is only for creating PRs. Because we are grouping all changes into one PR without this Renovate will be constantly rebasing that PR which we don't want since every time that happens another set of GHA status checks are kicked off.
   // Using a value of "conflicted" means that Renovate will only rebase PRs if they are in a conflicted state. See https://docs.renovatebot.com/configuration-options/#rebasewhen


### PR DESCRIPTION
https://docs.renovatebot.com/known-limitations/#timeschedule-based-limitations

> For this reason, you should set your schedule window to at least three or four hours. This makes it likely that Renovate bot checks your repository at least once during the schedule.

